### PR TITLE
Remove aui prefixes from property names

### DIFF
--- a/content/action.html
+++ b/content/action.html
@@ -1,6 +1,6 @@
 
 <section class="property" id="action-explanation">
-	<h2>aui-action</h2>
+	<h2>action</h2>
 	<section>
 		<h3>Description</h3>
     	<div class="property-description">
@@ -11,7 +11,7 @@
     <section id="action-example">
     	<h3>Example</h3>
     	<div class="property-example" >               	
-                	<p>The below example section show how aui-action used when coding.</p>
+                	<p>The below example section show how <code>action</code> used when coding.</p>
     				<pre class="example" title="Action Using ARIA">
        				<p>For example: &lt;button aui-action=&quot;undo&quot; &gt;Revert&lt;/button&gt;</p></pre>
         			<p>A personalization agent may add a symbol, replace the text with a more familiar term, or give it a specific presentation. Note that there is no default value.</p>			
@@ -48,7 +48,7 @@
 						</tr>
 					</tbody>
 		</table>
-    	<p>The following could be supported values of <code>aui-action</code> for buttons. Note that The following items represent an option or control that allows you to perform the action. They do not represent page regions.</p>
+    	<p>The following could be supported values of <code>action</code> for buttons. Note that The following items represent an option or control that allows you to perform the action. They do not represent page regions.</p>
     </section>
 
     <section>

--- a/content/destination.html
+++ b/content/destination.html
@@ -1,5 +1,5 @@
 <section class="property" id="destination-explanation">
-	<h2>aui-destination</h2>
+	<h2>destination</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -9,7 +9,7 @@
 	</section>
 	<section id="destination-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-destination</code> used when coding.</p>
+		<p>The below example section show how <code>destination</code> used when coding.</p>
     	<pre class="example" title="Action Using ARIA">
         <pre class="example" title="Destination Using ARIA">&lt;a href=&quot;home.html&quot; aui-destination=&quot;home&quot;&gt;our main page&lt;/a&gt;</pre>
 		<p>See the <a href="https://rawgit.com/ayelet-seeman/coga.personalisation/demo/conactUs.html">destination sample user experience</a>.</p>

--- a/content/distraction.html
+++ b/content/distraction.html
@@ -1,17 +1,17 @@
 <section id="distraction-explanation">
-	<h2>aui-distraction</h2>
+	<h2>distraction</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
 			<p>This attribute should be used on non essential, detracting content, so that people who have problems keeping focus can turn them off. An example user experiences would be to hide all distraction content.</p>
 			<p><strong>Supported values: </strong>animations, auto-starting, moving, ad, message, chat , overlay, popup<br /> Auto-changing (logs) third-party, offer ( includes suggestions).</p>
 			<p>Note that there is no default value.</p>
-			<p>Note that elements with the aui-distraction attribute should also have a label or accessible name.</p>
+			<p>Note that elements with the <code>distraction</code> attribute should also have a label or accessible name.</p>
 		</div>
 	</section>
 	<section id="distraction-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-distraction</code> used when coding.</p>
+		<p>The below example section show how <code>distraction</code> used when coding.</p>
    		<div class="example">
     	<div class="example-title marker"><span>Example:</span><span style="text-transform: none"> Distraction Using ARIA</span>
     	</div>

--- a/content/field.html
+++ b/content/field.html
@@ -1,18 +1,18 @@
 <section class="property" id="field-explanation">
-	<h2>aui-field</h2>
+	<h2>field</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
 			<p><code>field</code> provides the context of a text input field such as a text box. It is typically used on an input of type text, or element with a responding role.</p>
 			<p>A personalization agent may add a symbol, replace the text with a more familiar term, or give it a specific presentation. Note that there is no default value.</p><p>The user experience may include filling in the field and adding an icon.</p>
-			<p>aui-field values that would typically be on form controls and would have a user context - for example phone would relate to the user's phone. Note that there is no default value.</p>
+			<p><code>field</code> values that would typically be on form controls and would have a user context - for example phone would relate to the user's phone. Note that there is no default value.</p>
 			<p>Note they can be more then one value for a field, such as <code>aui-field=&quot;country postcode&quot;</code></p>
 		</div>
 	</section>
 
 	<section id="field-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-field</code> used when coding.</p>
+		<p>The below example section show how <code>field</code> used when coding.</p>
     	<pre class="example" title="Fields Using ARIA">
          <p>&lt;input type="text" name="fname" aui-field=&quot;phone&quot;/&gt;</p>
 		</pre>

--- a/content/simplification.html
+++ b/content/simplification.html
@@ -1,5 +1,5 @@
 <section class="property" id="simplification-explanation">
-	<h2>aui-simplification</h2>
+	<h2>simplification</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -7,7 +7,7 @@
 							<p>This allows simplified interfaces with less options or interfaces that emphasize critical features. Adaptations can be based on personalization settings. </p>
 						
 
-							 <p class="ednote">This was formerly aui-importance. However different people may feel that sections that would be hidden in a simplified version are still very important, such as marketing content or legal terms.)</p>
+							 <p class="ednote">This was formerly <code>importance</code>. However different people may feel that sections that would be hidden in a simplified version are still very important, such as marketing content or legal terms.)</p>
 
 							<div class="note">
 								<p>These semantics aid simplification. But what content is most useful to a user varies from user to user. For example, men may be more interested in mens clothing, and may not be interested in the more frequently use womens clothing option. For that reason we may add context for elements that will help the personalization agent select the most useful content for a given user (see the <a href="#context">context</a> attribute). This is also necessary for reminders (see bellow).</p>
@@ -17,7 +17,7 @@
 	</section>
 	<section id="simplification-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-simplification</code> used when coding.</p>
+		<p>The below example section show how <code>simplification</code> used when coding.</p>
     	<div class="example">
     		<div class="example-title marker"><span>Example:</span><span style="text-transform: none"> Simplification Using ARIA</span>
     		</div>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -1,5 +1,5 @@
 <section id="symbol-explanation">
-	<h2>aui-symbol</h2>
+	<h2>symbol</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -12,7 +12,7 @@
 	</section>
 	<section id="symbol-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-symbol</code> used when coding.</p>
+		<p>The below example section show how <code>symbol</code> used when coding.</p>
     	<div class="example">
     	<div class="example-title marker"><span>Example:</span><span style="text-transform: none"> Symbol Using ARIA</span>
     	</div>

--- a/content/use-cases.html
+++ b/content/use-cases.html
@@ -2,7 +2,7 @@
                     <h3>Simplification</h3>
                     <p><b>Requirement</b>: The user must be able to request a way to identify and differentiate between critical features, medium features and less important features. These need to be defined as important from a user perspective in the content. Typically, critical features may be used by many or most users, 90% of the time or more. High important features would be above 60% use. Medium important features would be 20% of users use it 20% of the time. Under 20% usage would be of low importance.</p>
                     <p><b>User experience</b>: Based on personalization setting the user can see less options. A sample user experience is available at <a href="https://rawgit.com/ayelet-seeman/coga.personalisation/demo/conactUs.html">https://rawgit.com/ayelet-seeman/coga.personalisation/demo/conactUs.html </a></p>
-                    <p>Relevant properties: <a href="#x3-4-aui-simplification">simplification</a></p>
+                    <p>Relevant properties: <a href="#simplification"><code>simplification</code></a></p>
 </section>
 <section id="use_case_adding_context">
                     <h3>Adding Context</h3>
@@ -15,7 +15,7 @@
                     </ul>
                     <p>For that we need to standardize supportive syntax and terms that can be linked to associated symbols, terms, translations and explanations, for the individual, via an attribute.</p>
                     <p><b>Example user experience:</b> If an author gives to a button a role "send" then, without any work by the author, the button could be automatically rendered with a symbol, term, and/or tooltips that is understandable by a particular user. It could automatically imply F1 help that explains the send function in simple terms. It could be identified with a keyboard short cut that will always be used for send. In addition it could be identified as important and always rendered, or rendered as a large button. This would enable a consistent UI experience across applications and websites.</p>
-                    <p>Relevant properties: <a href="#x3-1-aui-action">action</a>, <a href="#x3-2-aui-destination">destination</a>, <a href="#x3-3-aui-field">field</a></p>
+                    <p>Relevant properties: <a href="#action"><code>action</code></a>, <a href="#destination"><code>destination</code></a>, <a href="#field"><code>field</code></a></p>
                     <section id="use_case_general_context">
                         <h4>General Context</h4>
                         <p><b>Requirement: </b> One important factor in optimizing the personalization of a product or service is to ensure that the personalization is appropriate for the current context of use as well as what is relevant for the user. For example a female user with a cognitive disability may need less options, and options that are for men are less likely to be relevant for her and may be demoted to bellow the scroll or placed under a &quot;more option&quot; button.</p>

--- a/help/alternative.html
+++ b/help/alternative.html
@@ -1,9 +1,9 @@
 <section id="alternative-explanation">
-	<h2>aui-alternative</h2>
+	<h2>alternative</h2>
   <section>
     <h3>Description</h3>
     <div class="property-description">
-          <p>Would be used on an alternative content as an alternative to more detailed or difficult to understand content. aui-alternative can be used on a span, div, link or image that servers as alternative content to it's direct parent element.</p>
+          <p>Would be used on an alternative content as an alternative to more detailed or difficult to understand content. <code>alternative</code> can be used on a span, div, link or image that servers as alternative content to it's direct parent element.</p>
           <p class="ednote">This data model may be too complex, so this property could undergo substantial changes.</p>
           <p><strong>Supported values:</strong>
           </p>
@@ -18,10 +18,10 @@
   </section>
 	<section id="alternative-example">
     <h3>Example</h3>
-	<p>The below example section show how <code>aui-alternative</code> used when coding.</p>
+	<p>The below example section show how <code>alternative</code> used when coding.</p>
     <div class="example"><div class="example-title marker"><span>Example</span><span style="text-transform: none">: Alternative Using ARIA</span></div>
 			<pre>&lt;div&gt;
-	&lt;span coga-alternative="easylang numberfree vocab1000" class="hidden"&gt;
+	&lt;span aui-alternative="easylang numberfree vocab1000" class="hidden"&gt;
  	   most people prefer simple text
   	&lt;/span&gt;
         In studies it was found that only 30% of users prefer long convoluted text

--- a/help/easylang.html
+++ b/help/easylang.html
@@ -1,5 +1,5 @@
 <section id="easylang-explanation">
-	<h2>aui-easylang</h2>
+	<h2>easylang</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -8,12 +8,12 @@
 				<p>User agents may also render hard text in a different way so that users will be able to identify text that has an alternative provided. </p>
 				<p>The content must still be understandable when a user agent replaces the original content with the simpler alternative.</p>
 				<p><strong>Supported values:</strong> String</p>
-				<p>Where aui-easylang should use as simple well-known words as possible, and active voicing, literal text, small simple sentences.Â Acronyms and abbreviations should be avoided, unless they are the common way to refer to an item.</p>
+				<p>Where <code>easylang</code> should use as simple well-known words as possible, and active voicing, literal text, small simple sentences.Â Acronyms and abbreviations should be avoided, unless they are the common way to refer to an item.</p>
 		</div>
 	</section>
 	<section id="easylang-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-easylang</code> used when coding.</p>
+		<p>The below example section show how <code>easylang</code> used when coding.</p>
    		<div class="example"><div class="example-title marker"><span>Example</span><span style="text-transform: none">: Easylang Using ARIA</span></div>
 			<pre>&lt;span aui-easylang="some text that is easy to read"> some convoluted obtuse text&lt;/span>&gt;</pre>
 			</div>

--- a/help/explain.html
+++ b/help/explain.html
@@ -1,5 +1,5 @@
 <section id="explain-explanation">
-	<h3>aui-explain</h3>
+	<h3>explain</h3>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -11,7 +11,7 @@
 	</section>
 	<section id="explain-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-explain</code> used when coding.</p>
+		<p>The below example section show how <code>explain</code> used when coding.</p>
   		<div class="example"><div class="example-title marker"><span>Example</span><span style="text-transform: none">: Explain Using ARIA</span></div>
 			<pre>aui-explain="press enter to send the email" </pre>
 		</div>

--- a/help/extrahelp.html
+++ b/help/extrahelp.html
@@ -1,5 +1,5 @@
 <section id="extrahelp-explanation">
-	<h3>aui-extrahelp</h3>
+	<h3>extrahelp</h3>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -12,7 +12,7 @@
 	</section>
 	<section id="extrahelp-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-extrahelp</code> used when coding.</p>
+		<p>The below example section show how <code>extrahelp</code> used when coding.</p>
     	<div class="example"><div class="example-title marker"><span>Example</span><span style="text-transform: none">: Extrahelp Using ARIA</span></div>
 			<pre>N/A</pre>
 			</div>

--- a/help/feedback.html
+++ b/help/feedback.html
@@ -1,5 +1,5 @@
 <section id="feedback-explanation">
-	<h2>aui-feedback</h2>
+	<h2>feedback</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -9,7 +9,7 @@
 	</section>
 	<section id="feedback-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-feedback</code> used when coding.</p>
+		<p>The below example section show how <code>feedback</code> used when coding.</p>
    		<div class="example"><div class="example-title marker"><span>Example</span><span style="text-transform: none">: Feedback Using ARIA</span></div>
 			<pre>aui-feedback="your email on birthdays was sent" </pre>
 			</div>

--- a/help/helptype.html
+++ b/help/helptype.html
@@ -1,14 +1,14 @@
 <section id="helptype-explanation">
-	<h3>aui-helptype</h3>
+	<h3>helptype</h3>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
-					<p>Would be used on additional content to indicate the type of extra help provided. <code>aui-helptype</code> can be used on a span, div, link or image that provides or redirects the user to additional help information.</p>
+					<p>Would be used on additional content to indicate the type of extra help provided. <code>helptype</code> can be used on a span, div, link or image that provides or redirects the user to additional help information.</p>
 				</div>
 	</section>
 	<section id="helptype-example">
 		<h3>Example</h3>
-	<p>The below example section show how <code>aui-helptype</code> used when coding.</p>
+	<p>The below example section show how <code>helptype</code> used when coding.</p>
     <div class="example"><div class="example-title marker"><span>Example</span><span style="text-transform: none">: Helptype Using ARIA</span></div>
 			<pre>&lt;button type="button" aui-extrahelp=&quot;uri2 uri3&quot; &gt;undo&lt;/button&gt;</pre>
 					<p>URI 2 may read: </p>

--- a/help/index.html
+++ b/help/index.html
@@ -12,7 +12,7 @@
 	<body>
 
 		<section id="abstract">
-			<p>This document list examples of the personalized help and support properties, this is an extension of <a href="../">Personalization Explainer 1.0</a>. including the properties of <code>aui-literal</code>, <code>aui-numberfree</code>, <code>aui-easylang</code>, <code>aui-alternative</code>, <code>aui-explain</code>, <code>aui-feedback</code>, <code>aui-moreinfo</code>,<code>aui-extrahelp</code>, <code>aui-helptype</code>. </p>
+			<p>This document list examples of the personalized help and support properties, this is an extension of <a href="../">Personalization Explainer 1.0</a>. including the properties of <code>literal</code>, <code>numberfree</code>, <code>easylang</code>, <code>alternative</code>, <code>explain</code>, <code>feedback</code>, <code>moreinfo</code>,<code>extrahelp</code>, <code>helptype</code>. </p>
 		</section>
 
 		<section id="sotd"></section>
@@ -20,7 +20,7 @@
 		<section class="informative" id="introduction">
 
 			<h1>Introduction</h1>
-			<p>This document list examples of the personalized help and support properties, this is an extension of <a href="../">Personalization Explainer 1.0</a>. including the properties of <code>aui-literal</code>, <code>aui-numberfree</code>, <code>aui-easylang</code>, <code>aui-alternative</code>, <code>aui-explain</code>, <code>aui-feedback</code>, <code>aui-moreinfo</code>,<code>aui-extrahelp</code>, <code>aui-helptype</code>. </p>
+			<p>This document list examples of the personalized help and support properties, this is an extension of <a href="../">Personalization Explainer 1.0</a>. including the properties of <code>literal</code>, <code>numberfree</code>, <code>easylang</code>, <code>alternative</code>, <code>explain</code>, <code>feedback</code>, <code>moreinfo</code>,<code>extrahelp</code>, <code>helptype</code>. </p>
 
 		</section>
 		<section>

--- a/help/literal.html
+++ b/help/literal.html
@@ -1,5 +1,5 @@
 <section id="literal-explanation">
-	<h2>aui-literal</h2>
+	<h2>literal</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -13,7 +13,7 @@
 	</section>
 	<section id="literal-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-literal</code> used when coding.</p>
+		<p>The below example section show how <code>literal</code> used when coding.</p>
     	<div class="example">
     	<div class="example-title marker"><span>Example:</span><span style="text-transform: none"> Symbol Using ARIA</span>
     	</div>

--- a/help/moreinfo.html
+++ b/help/moreinfo.html
@@ -1,5 +1,5 @@
 <section id="moreinfo-explanation">
-	<h2>aui-moreinfo</h2>
+	<h2>moreinfo</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -12,7 +12,7 @@
 	</section>
 	<section id="moreinfo-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-moreinfo</code> used when coding.</p>
+		<p>The below example section show how <code>moreinfo</code> used when coding.</p>
     	<div class="example"><div class="example-title marker"><span>Example</span><span style="text-transform: none">: Moreinfo Using ARIA</span></div>
 			<pre>N/A</pre>
 			</div>

--- a/help/numberfree.html
+++ b/help/numberfree.html
@@ -1,5 +1,5 @@
 <section id="numberfree-explanation">
-	<h2>aui-numberfree</h2>
+	<h2>numberfree</h2>
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
@@ -13,7 +13,7 @@
 	</section>
 	<section id="numberfree-example">
 		<h3>Example</h3>
-		<p>The below example section show how <code>aui-numberfree</code> used when coding.</p>
+		<p>The below example section show how <code>numberfree</code> used when coding.</p>
   		  <div class="example"><div class="example-title marker"><span>Example 1</span><span style="text-transform: none">: Numberfree Using ARIA</span></div>
 			<pre>&lt;span aui-numberfree=&quot;almost all&quot;&gt;9 out of 10 &lt;/span&gt;</pre>
 			</div>

--- a/help/use-cases.html
+++ b/help/use-cases.html
@@ -1,32 +1,32 @@
                 <section id="use_case_numberfree">
                     <h2>Number Free</h2>
-                    <p><strong>Requirement</strong>: Not everyone can understand numbers. We therefor suggest aui-numberfree for alternative text for people who can not understand the main content</p>
+                    <p><strong>Requirement</strong>: Not everyone can understand numbers. We therefor suggest <code>numberfree</code> for alternative text for people who can not understand the main content</p>
                     <p><strong>User experience:</strong></p>
                     <p>A suggested user experience would be: Numerical concepts could be rendered by the user agent slightly different so that the user knows a number free explanation is available. The user can then mouse over the content and a tooltips would give the number free value</p>
-                    <p>Relevant properties: <a href="#x3-2-aui-numberfree">numberfree</a></p>
+                    <p>Relevant properties: <a href="#numberfree"><code>numberfree</code></a></p>
                 </section>
                 <section id="use_case_language">
                     <h2>Language Type Support</h2>
                     <p><strong>Requirement: </strong>Sometimes you may want to provide a simplified version of a section of a page. For example, you may wish to provide a simplified summary of legal document, but still have a longer version for other users. These alternative versions may not be identical in content but maintain the gist of the original content.</p>
-                    <p>Relevant properties: <a href="#x3-4-aui-alternative">alternative</a>, <a href="#x3-3-aui-easylang">easylang</a></p>
+                    <p>Relevant properties: <a href="#alternative"><code>alternative</code></a>, <a href="#easylang"><code>easylang</code></a></p>
                 </section>
                 <section id="use_case_literal">
                     <h2>Non-literal Text and Images</h2>
                     <p><strong>Requirement: </strong>Not everyone can understand non-literal text and icons such as metaphors, idioms etc. We need a tag that identifies text or images as non literal and allows the author to explain non-literal text and images to users.</p>
                     <p><strong>User experience:</strong></p>
                     <p>A suggested user experience would be: Non literal content could be rendered by the user agent slightly differently so that the user knows that this content should not be taken literally and that a literal explanation is available. The user can then mouse over the content and a tooltips would give the literal value.</p>
-                    <p>Relevant properties: <a href="#x3-1-aui-literal">literal</a></p>
+                    <p>Relevant properties: <a href="#literal"><code>literal</code></a></p>
                 </section>
                 <section id="use_case_morehelp">
                     <h3>More Help</h3>
                     <p><strong>Requirement: </strong>Some users may need additional information or specifically additional help information. We request additional attributes so that an author can indicate the existence of this additional information.</p>
-                    <p>Relevant properties: <a href="#x3-7-aui-moreinfo">moreinfo</a>, <a href="#x3-8-aui-extrahelp">extrahelp</a>, <a href="#x3-9-aui-helptype">helptype</a></p>
+                    <p>Relevant properties: <a href="#moreinfo"><code>moreinfo</code></a>, <a href="#extrahelp"><code>extrahelp</code></a>, <a href="#helptype">helptype</a></p>
                 </section>
                 <section id="use_case_explain">
                     <h2>Explain and Feedback</h2>
                     <p><strong>Requirement: </strong></p>
                     <p>Some users need additional help. We request an attribute where the author can provide additional information or what just happened.</p>
-                    <p>Relevant properties: <a href="#x3-6-aui-feedback">feedback</a>, <a href="#x3-5-aui-explain">explain</a></p>
+                    <p>Relevant properties: <a href="#feedback"><code>feedback</code></a>, <a href="#explain"><code>explain</code></a></p>
                 </section>
                 <section id="use_case_potential_feature">
                     <h2>Potential Features</h2>


### PR DESCRIPTION
The prefix should not be used in property names. It is needed for
implementation in some metadata language; that is addressed in part by
#50 so this depends ion that pull request.

Examples are not touched and retain the prefix, since they are attribute
examples which would need the prefix. In the future we should provide
examples using multiple metatdata languages to help distinguish property
names from implementation of property names in metadata languages.

This closes #48.