### PR TITLE
Instance of "attribute" to "defined value"

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -20,7 +20,7 @@
 		
 		<em>This section is non-normative.</em>
 		
-		<p>This document lists examples of the Personalization Tools attributes. This is an extension of the <a href="https://www.w3.org/TR/personalization-semantics-1.0/">Personalization Semantics Explainer 1.0</a> and includes the defined values: <code>stepindicator</code>, <code>step</code>, <code>steplocation</code>, <code>stepstatus</code>, <code>messageimportance</code>, <code>messagefrom</code>, <code>messagecontext</code>, and <code>messagetime</code>.</p> 
+		<p>This document lists examples of the Personalization Tools defined values. This is an extension of the <a href="https://www.w3.org/TR/personalization-semantics-1.0/">Personalization Semantics Explainer 1.0</a> and includes the defined values: <code>stepindicator</code>, <code>step</code>, <code>steplocation</code>, <code>stepstatus</code>, <code>messageimportance</code>, <code>messagetime</code>, <code>messagegroupname</code>, and <code>messagegroupmember</code>.</p> 
 		</section>
 
 		<section>


### PR DESCRIPTION
As per JF's call out. There was an oversight on a previous PR which intended to make a global change of the word "attribute" to "defined value".