### PR TITLE
Use the  permissive document license for non-REC track document

### DIFF
--- a/requirements/respec-config.js
+++ b/requirements/respec-config.js
@@ -22,7 +22,6 @@ var respecConfig = {
     // if you wish the publication date to be other than today, set this
     //publishDate:  "2017-05-09",
     copyrightStart:  "2018",
-    license: "w3c-software",
 
     // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
     // and its maturity status


### PR DESCRIPTION
Fixes issue raised at https://github.com/w3c/transitions/issues/212