### PR TITLE
Typos in simplification example

### DIFF
--- a/content/simplification.html
+++ b/content/simplification.html
@@ -18,7 +18,7 @@
 			<li>In this example, the <code>simplification</code> attribute is used on critical content &mdash; a newsletter from an elementary school. Important announcements about an early school dismissal is in a list of other activities. If this important information is missed, the parents might not be home in time, putting children at risk.
 		      	<pre class="example" title="Simplification Using data-simplification">
 &lt;p&gt;Years 2 - 3 are putting on a play next Tuesday. 
-&lt;b data-simplification="critical"&gt;Thefore school will close at 1 pm on Tuesday &lt;/b&gt; 
+&lt;b data-simplification="critical"&gt;Therefore school will close at 1 pm on Tuesday&lt;/b&gt; 
  so we can get the school hall ready.&lt;/p&gt;</pre></li>
 		</ol>
 


### PR DESCRIPTION
Fix a spelling error and spurious space character in Example 6.