### PR TITLE
Add action, destination, purpose standalone matrix

### DIFF
--- a/review-of-approaches-for-action-destination-purpose.html
+++ b/review-of-approaches-for-action-destination-purpose.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="generator" content="pandoc">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+		<title>Review of approaches for Action, Destination, and Purpose: standalone matrix</title>
+		<style>
+body { margin: 0; font-family: Verdana, sans-serif; }
+table { border-collapse: collapse; }
+tr { border-bottom: 1px solid black; }
+th, td {
+	text-align: center;
+	border-right: 1px dotted black;
+	padding: 1em;
+}
+th { background-color: #eee; }
+th > p:not(:nth-child(1)) { font-weight: normal; }
+th[scope="row"] { min-width: 15em; }
+pre > code.sourceCode { white-space: normal; }
+footer { margin-left: 1em; }
+
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+		</style>
+	</head>
+	<body>
+		<main>
+			<table>
+				<thead>
+					<tr class="header">
+						<th>
+							<strong>Use-case</strong>
+						</th>
+						<th>
+							<strong>Current spec</strong>
+						</th>
+						<th>
+							<p>
+							<strong>Current spec with some shared attribute values</strong>
+							</p>
+							<p>
+							<span class="citation" data-cites="action">@action</span> and <span class="citation" data-cites="destination">@destination</span> are separate but some of the values are shared.
+							</p>
+						</th>
+						<th>
+							<p>
+							<strong>Merging action and destination</strong>
+							</p>
+							<p>
+							<span class="citation" data-cites="action">@action</span> and <span class="citation" data-cites="destination">@destination</span> are merged and called <span class="citation" data-cites="action-destination">@action-destination</span> (a placeholder name)
+							</p>
+							<p>
+							<span class="citation" data-cites="purpose">@purpose</span> is used for input controls, and static content.
+							</p>
+						</th>
+						<th>
+							<p>
+							<strong>Merging action, destination and purpose</strong>
+							</p>
+							<p>
+							Instead of <span class="citation" data-cites="action">@action</span>, <span class="citation" data-cites="destination">@destination</span> and <span class="citation" data-cites="purpose">@purpose</span>, there is a single <span class="citation" data-cites="purpose">@purpose</span> attribute.
+							</p>
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr class="odd">
+						<th scope="row">
+							<p>
+							<strong>Copy to clipboard button</strong>
+							</p>
+							<p>
+							A traditional button that would trigger a copy of the selected content to be placed on the clipboard.
+							</p>
+						</th>
+						<td>
+							<div class="sourceCode" id="cb1"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action</span><span class="ot">=</span><span class="st">"copy"</span><span class="kw">&gt;</span>Copy<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb2"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action</span><span class="ot">=</span><span class="st">"copy"</span><span class="kw">&gt;</span>Copy<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb3"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action-destination</span><span class="ot">=</span><span class="st">"copy"</span><span class="kw">&gt;</span>Copy<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb4"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"copy"</span><span class="kw">&gt;</span>Copy<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="even">
+						<th scope="row">
+							<p>
+							<strong>Help link</strong>
+							</p>
+							<p>
+							A traditional hyperlink to a separate HTML document that provides help information.
+							</p>
+						</th>
+						<td>
+							<div class="sourceCode" id="cb5"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">destination</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb6"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">destination</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb7"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">action-destination</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb8"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="odd">
+						<th scope="row">
+							<p>
+							<strong>Telephone number input</strong>
+							</p>
+							<p>
+							A traditional input element that requests the user’s home phone number. HTML autocomplete values are used to convey the meaning.
+							</p>
+						</th>
+						<td>
+							<div class="sourceCode" id="cb9"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;input</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"home tel"</span><span class="kw">&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb10"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;input</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"home tel"</span><span class="kw">&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb11"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;input</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"home tel"</span><span class="kw">&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb12"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;input</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"home tel"</span><span class="kw">&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="even">
+						<th scope="row">
+							<p>
+							<strong>Button to submit log-in form</strong>
+							</p>
+							<p>
+							The button on the actual log in form (whether this is on a separate
+							page, or in a dialog) to submit the log in form to the server.
+							</p>
+						</th>
+						<td>
+							<div class="sourceCode" id="cb13"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">type</span><span class="ot">=</span><span class="st">"submit"</span> <span class="er">action</span><span class="ot">=</span><span class="st">"submit"</span><span class="kw">&gt;</span>Submit<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb14"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">type</span><span class="ot">=</span><span class="st">"submit"</span> <span class="er">action</span><span class="ot">=</span><span class="st">"submit"</span><span class="kw">&gt;</span>Submit<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb15"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">type</span><span class="ot">=</span><span class="st">"submit"</span> <span class="er">action-destination</span><span class="ot">=</span><span class="st">"submit"</span><span class="kw">&gt;</span>Submit<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb16"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">type</span><span class="ot">=</span><span class="st">"submit"</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"submit"</span><span class="kw">&gt;</span>Submit<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="odd">
+						<th scope="row">
+							<p>
+							<strong>Link to log in page</strong>
+							</p>
+							<p>
+							Another example of a traditional hyperlink to a separate HTML document,
+							specifically one that provides a form that allows the user to log in.
+							</p>
+						</th>
+						<td>
+							<div class="sourceCode" id="cb17"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">destination</span><span class="ot">=</span><span class="st">"signin"</span><span class="kw">&gt;</span>Log in<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb18"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">destination</span><span class="ot">=</span><span class="st">"signin"</span><span class="kw">&gt;</span>Log in<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb19"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">action-destination</span><span class="ot">=</span><span class="st">"signin"</span><span class="kw">&gt;</span>Log in<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb20"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"signin"</span><span class="kw">&gt;</span>Log in<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="even">
+						<th scope="row">
+							<p>
+							<strong>Link to start the checkout process on a new page</strong>
+							</p>
+							<p>
+							A traditional HTML link that initiates the checkout process by taking
+							the user to a simplified full-page experience (common with online
+							shopping sites, to improve success rates).
+							</p>
+							<p>
+							Note: “checkout” is specified as an action so is not valid to attach to links in the current spe
+							</p>
+						</th>
+						<td>
+							(out of scope)
+						</td>
+						<td>
+							<div class="sourceCode" id="cb21"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">destination</span><span class="ot">=</span><span class="st">"checkout"</span><span class="kw">&gt;</span>Check out<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb22"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">action-destination</span><span class="ot">=</span><span class="st">"checkout"</span><span class="kw">&gt;</span>Check out<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb23"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;a</span> <span class="er">href</span><span class="ot">=</span><span class="st">"..."</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"checkout"</span><span class="kw">&gt;</span>Check out<span class="kw">&lt;/a&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="odd">
+						<th scope="row">
+							<p>
+							<strong>Help button</strong>
+							</p>
+							<p>
+							A traditional button that triggers a dialog to open; the contents of the dialog provide help information.
+							</p>
+						</th>
+						<td>
+							<div class="sourceCode" id="cb24"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action</span><span class="ot">=</span><span class="st">"opens-in-page-dialog"</span> <span class="er">destination</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb25"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb26"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action-destination</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb27"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"help"</span><span class="kw">&gt;</span>Help<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="even">
+						<th scope="row">
+							<p>
+							<strong>Contact telephone number (content)</strong>
+							</p>
+							<p>
+							Static content in the document that has some meaning.
+							</p>
+						</th>
+						<td>
+							(out of scope)
+						</td>
+						<td>
+							(out of scope)
+						</td>
+						<td>
+							<div class="sourceCode" id="cb28"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;p</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"work tel"</span><span class="kw">&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb29"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;p</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"work tel"</span><span class="kw">&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+					<tr class="odd">
+						<th scope="row">
+							<p>
+							<strong>Button to open a log in form</strong>
+							</p>
+							<p>
+							A traditional button that opens a dialog on the current page that contains a log in form.
+							</p>
+						</th>
+						<td>
+							(out of scope)
+						</td>
+						<td>
+							<div class="sourceCode" id="cb30"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action</span><span class="ot">=</span><span class="st">"signin"</span><span class="kw">&gt;</span>Log in<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb31"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">action-destination</span><span class="ot">=</span><span class="st">"signin"</span><span class="kw">&gt;</span>Log in<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+						<td>
+							<div class="sourceCode" id="cb32"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">&lt;button</span> <span class="er">purpose</span><span class="ot">=</span><span class="st">"signin"</span><span class="kw">&gt;</span>Log in<span class="kw">&lt;/button&gt;</span></span></code></pre></div>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</main>
+		<footer>
+			<p>Last updated: 2021-07-02</p>
+			<p><strong>Note:</strong> if the <a href="https://github.com/w3c/personalization-semantics/wiki/Review-of-approaches-for-Action,-Destination,-and-Purpose">approach review wiki page</a> gets updated, we must update this table.</p>
+		</footer>
+	</body>
+</html>


### PR DESCRIPTION
This brings the standalone matrix for the review of approaches into the repo (previous versions were posted to the mailing list).

Note: if [the approach review wiki page](https://github.com/w3c/personalization-semantics/wiki/Review-of-approaches-for-Action,-Destination,-and-Purpose) changes, we must update this too. I've included the last-updated date and a note to this effect in the content of this file.

Questions (I think we need the go-ahead from everyone here before merging):
* @ruoxiran: I checked the [Travis script](https://github.com/w3c/personalization-semantics/blob/main/.travis.yml) and it sounds like it'll be fine to add this file (in that it won't get automatically overwritten) but just wanted to check if you had any concerns? Thanks in advance.
* @snidersd, @lwolberg: Are you both happy with me leaving this in the root directory of this branch, and with the filename?