### PR TITLE
Re-work simplification example

### DIFF
--- a/content/simplification.html
+++ b/content/simplification.html
@@ -17,9 +17,7 @@
     	&lt;input value="Submit" type="submit" data-simplification="critical"/&gt;</pre></li>
 			<li>In this example, the <code>simplification</code> attribute is used on critical content &mdash; a newsletter from an elementary school. Important announcements about an early school dismissal is in a list of other activities. If this important information is missed, the parents might not be home in time, putting children at risk.
 		      	<pre class="example" title="Simplification Using data-simplification">
-&lt;p&gt;Years 2 - 3 are putting on a play next Tuesday. 
-&lt;strong data-simplification="critical"&gt;Therefore school will close at 1 pm on Tuesday&lt;/strong&gt; 
- so we can get the school hall ready.&lt;/p&gt;</pre></li>
+&lt;p&gt;&lt;strong data-simplification="critical"&gt;School will close at 1 pm on Tuesday.&lt;/strong&gt; This is because Years 2-3 are putting on a play and we need to get the school hall ready.&lt;/p&gt;</pre></li>
 		</ol>
 
     </section>
@@ -75,7 +73,7 @@
 								<tr>
 									<th class="value-name" scope="row"><strong class="default"><code>medium</code> (default)</strong></th>
 									<td class="value-description">
-                                        The <code>medium</code> setting should be used on: 
+                                        The <code>medium</code> setting should be used on:
                                     <ul>
 										<li> Controls and content that are used frequently but are not essential for the key functioning of the application. Example: The delete button for an email draft in an email application.</li>
 										<li> Controls and content that are sometimes important for a user to interact with the site, such as settings to change colors or fonts. </li>
@@ -88,7 +86,7 @@
 									<th class="value-name" scope="row"><code>low</code></th>
 									<td class="value-description">
                                         The <code>low</code> setting should be used on:
-									<ul><li>Controls and content that are rarely used or only used by advanced users. Example: The terms and services or the archive button for an email application.</li></ul> 
+									<ul><li>Controls and content that are rarely used or only used by advanced users. Example: The terms and services or the archive button for an email application.</li></ul>
 							     </td>
 								</tr>
 


### PR DESCRIPTION
Preview: https://raw.githack.com/w3c/personalization-semantics/simplification-example-logic/content/index.html#example-6-simplification-using-data-simplification

This also removes some spaces at the ends of lines.

**Question:** should the examples be indented? [Example 7](https://raw.githack.com/w3c/personalization-semantics/simplification-example-logic/content/index.html#example-7-distraction-using-data-distraction) and [Example 11](https://raw.githack.com/w3c/personalization-semantics/simplification-example-logic/content/index.html#example-11-symbols-for-individual-words) are; others are short enough to not need wrapping.

Fixes #187 