### PR TITLE
Snidersd patch 1

### DIFF
--- a/content/action.html
+++ b/content/action.html
@@ -155,7 +155,7 @@
 						</tr>
 						<tr>
 							<th class="value-name" scope="row">escape</th>
-							<td class="value-description">Typically used to abort, cancel or change what is currently being displayed on the screen. A common application of the the esc key is to leave full screen mode.(Implied simplification = "critical", the reason being if there is no [cancel] option [escape] must be present to abort the operation)</td>
+							<td class="value-description">Typically used to abort, cancel or change what is currently being displayed on the screen. A common application of the the esc key is to leave full screen mode. (Implied <a href="#simplification-explanation">simplification</a> = "critical", the reason being if there is no [cancel] option [escape] must be present to abort the operation)</td>
 						</tr>
             
 						<tr>
@@ -184,7 +184,7 @@
 						</tr>
 						<tr>
 							<th class="value-name" scope="row">left</th>
-							<td class="value-description">Changes the location of the selected item(s) to the left based on physical positioning. Note that the logical implication may depend on the dirction of the page. If the logic is important, use next or previous.</td>
+							<td class="value-description">Changes the location of the selected item(s) to the left based on physical positioning. Note that the logical implication may depend on the direction of the page. If the logic is important, use next or previous.</td>
 						</tr>
            
    						<tr>

--- a/content/index.html
+++ b/content/index.html
@@ -106,7 +106,7 @@
 
 				<p>Although this specification does not expose personal preferences and personal information, third party user agents or proxy server(s) acting upon our semantic information may need to store personal preferences on how to present content to a specific user. It is recommended that any user agent or proxy server implements best practices to protect all personal preferences and personal information.</p>
 		
-<p>Any user agent with user setting are recommended to follow best practices to keep user information secure.</p>
+<p>Any user agent with user settings are recommended to follow best practices to keep user information secure.</p>
 		<p>The Privacy and Security Considerations of Personalization Semantics Content Module is also discussed at <a href="https://github.com/w3c/personalization-semantics/issues/131">issue #131</a>.</p>
 		
 		</section>

--- a/content/purpose.html
+++ b/content/purpose.html
@@ -19,8 +19,8 @@
     	<pre class="example" title="Field Using data-purpose">
          &lt;input type="text" name="telnum" data-purpose=&quot;tel&quot;/&gt;</pre></li>
 		 
-			<li>The following is an example using the <code>purpose</code> attribute on a textare input collecting both Country and Postal-code information.
-    	<pre class="example" title="Field Using data-purpose - space sperated values">
+			<li>The following is an example using the <code>purpose</code> attribute on a textarea input collecting both Country and Postal-code information.
+    	<pre class="example" title="Field Using data-purpose - space separated values">
          &lt;textarea name="country_zip" data-purpose=&quot;country-name postal-code&quot;/&gt;</pre></li>
 	
 		</ol>
@@ -189,7 +189,7 @@
 						</tr>
 						<tr>
 							<th class="value-name" scope="row">date-end</th>
-							<td class="value-description">Set the end time of an event  
+							<td class="value-description">Set the end time of an event.  
                             <em class="note">We may remove this or harmonize with other date time standards.</em>
                             <em class="ednote">At risk pending implementations.</em>
                             </td>
@@ -293,7 +293,7 @@
 						</tr>
 						<tr>
 							<th class="value-name" scope="row">tel</th>
-							<td class="value-description">Full telephone number, including country code .</td>
+							<td class="value-description">Full telephone number, including country code.</td>
 						</tr>
 						<tr>
 							<th class="value-name" scope="row">tel-area-code</th>
@@ -321,7 +321,7 @@
 						</tr>
 						<tr>
 							<th class="value-name" scope="row">tel-national</th>
-							<td class="value-description">Telephone number without the county code component, with a country-internal prefix applied if applicable.</td>
+							<td class="value-description">Telephone number without the country code component, with a country-internal prefix applied if applicable.</td>
 						</tr>
 						<tr>
 							<th class="value-name" scope="row">time-end</th>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -11,7 +11,7 @@
 						<li>facilitating symbol-set translation: loading alternative, locally stored symbols that the user is familiar with, so they do not have to learn new symbols across different applications.</li>
 					</ul>	
 					</p>
-                    <p>In some languages words and symbols are conjugated with sex or tense. In these case more then one value maybe needed to map to a symbol. Authors should join values that map to a single conjugated word with a \ + \ sign with a space on each side of the \ + \ sign. (User agent may choose to accept values for a conjugated term that have been separated without the spaces.)
+                    <p>In some languages words and symbols are conjugated with sex or tense. In these cases more than one value maybe needed to map to a symbol. Authors should join values that map to a single conjugated word with a \ + \ sign with a space on each side of the \ + \ sign. (User agents may choose to accept values for a conjugated term that have been separated without the spaces.)
 See <a href="https://github.com/w3c/personalization-semantics/wiki/Best-practices-for-symbol-values">best practices for symbol values</a>.
 			</p>			    
 			    


### PR DESCRIPTION
Content Module - Fix typos:

- 3.1.4 Values > escape - made the word simplification a link for consistency with other instances on the page.
- 3.1.4 Values > left - the word direction is misspelled as “dirction”.
- 3.3.2 Example >  number 2 the word textarea  was misspelled as “textare” 
- 3.3.2 Example >  EXAMPLE 4  he word separated  was misspelled as “sperated” 
- 3.3.4 Values > date-end value’s first sentence is missing a period at the end.
- 3.3.4 Values > tel description has a space before the period at the end of the sentence.
- 3.3.4 Values > tel-national  description includes “county code” changed to “country code”.
- 3.6.1 Description > first paragraph after the bullets > second sentence - changed "case more then" "to cases more than" and made the word agent plural. 
In some languages words and symbols are conjugated with sex or tense.  In these cases more than one value maybe needed to map to a symbol.  Authors should join values that map to a single conjugated word with a \ + \ sign with a space on each side of the \ + \ sign. (User agents may choose to accept values for a conjugated term that have been separated without the spaces.) See best practices for symbol values.
- 4.0 Privacy and Security Considerations - made the word setting plural
Any user agent with user settings are recommended to follow best practices to keep user information secure.