### PR TITLE
Simplify symbol examples

### DIFF
--- a/content/symbol.html
+++ b/content/symbol.html
@@ -11,14 +11,8 @@
 						<li>facilitating symbol-set translation: loading alternative, locally stored symbols that the user is familiar with, so they do not have to learn new symbols across different applications.</li>
 					</ul>
 					</p>
-                    <p>In some languages words and symbols are conjugated with sex or tense. In these cases more than one value maybe needed to map to a symbol. Authors should join values that map to a single conjugated word with a \ + \ sign with a space on each side of the \ + \ sign. (User agents may choose to accept values for a conjugated term that have been separated without the spaces.)
-See <a href="https://github.com/w3c/personalization-semantics/wiki/Best-practices-for-symbol-values">best practices for symbol values</a>.
-			</p>
-
- <p>When there is more than one concept that is not part of a single conjugated term, multiple concepts can be referenced by separating them
-with white space. The order of multiple concepts should be the same as used in typical speech in the natural language of the content.
-</p>
-
+					<p>In some languages words and symbols are conjugated with sex or tense. In these cases more than one value maybe needed to map to a symbol. Authors should join values that map to a single conjugated word with a plus (<code>+</code>) sign (with no spaces between the values). See <a href="https://github.com/w3c/personalization-semantics/wiki/Best-practices-for-symbol-values">best practices for symbol values</a>.</p>
+<p>When there is more than one concept that is not part of a single conjugated term, multiple concepts can be referenced by separating them with white space. The order of multiple concepts should be the same as used in typical speech in the natural language of the content.</p>
 			<p>The reference numbers are the same references numbers used in Bliss (BCI numbers). Here is a link to the <a href="http://www.blissymbolics.net/BCI-AV_2020-03-09/BCI-AV_2020-03-09_(en+sv+no+fi)+derivations+symbols_8483-27158.pdf">BCI numbers (PDF)</a> and <a href="http://www.blissymbolics.net/BCI-AV_2020-03-09/BCI-AV_2020-03-09_(en+sv+no+fi+hu+de+nl+af+ru+lv+po+fr+es+pt+it+dk)+derivations+symbols_8483-27158.pdf">additional language translations (PDF)</a> at the time of publication and the <a href="http://www.blissymbolics.org/index.php/licensing">copyright licensing</a> from Bliss. For additional updates after publication see our <a href="https://github.com/w3c/personalization-semantics/wiki/Best-practices-for-symbol-values">best practices</a> for symbols page.</p>
 				</div>
 	</section>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -23,10 +23,10 @@
 		<li>Symbols for individual words.
         <pre class="example" title="Symbols for individual words">&lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; of &lt;span data-symbol=&quot;17511&quot;&gt;Tea&lt;/span&gt;</pre>
 		</li>
-		<li>Symbols used with an image (<code>alt</code> text represented as symbols).
-        <pre class="example" title="Symbols used with an image">&lt;img src="cuptea.png" data-symbol="13621" alt="Cup"/&gt;</pre>
+		<li>Symbols used with an image (<code>alt</code> text represented as a symbol).
+        <pre class="example" title="Symbols used with an image">&lt;img src="cup.png" data-symbol="13621" alt="Cup"/&gt;</pre>
 		</li>
-		<li>Symbols with conjugation. In this example a symbol is used for "her name" for the conjugated Hebrew word, <span lang="he" dir="rtl">שמה</span>. The /+/ is used with no spaces to join the conjugated values, "her" (14707) and "name" (15691). If the gender is not important, you can just use the value for name (15691).
+		<li>Symbols with conjugation. In this example a symbol is used for "her name" for the conjugated Hebrew word, <span lang="he" dir="rtl">שמה</span>. The plus sign is used with no spaces to join the conjugated values, "her" (14707) and "name" (15691). If the gender is not important, you can just use the value for name (15691).
 		<pre class="example" title="Symbols with conjugation">&lt;img src="her-name.png" alt="שמה" data-symbol="15691+14707"/></pre>
 		</li>
 	   </ol>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -7,19 +7,19 @@
 					<p>The <code>symbol</code> attribute accepts a numeric reference number.</p>
 					<p>A personalization agent can then augment or translate User Interfaces by:</p>
 					<ul>
-						<li>converting text to symbols,</li> 
+						<li>converting text to symbols,</li>
 						<li>facilitating symbol-set translation: loading alternative, locally stored symbols that the user is familiar with, so they do not have to learn new symbols across different applications.</li>
-					</ul>	
+					</ul>
 					</p>
                     <p>In some languages words and symbols are conjugated with sex or tense. In these cases more than one value maybe needed to map to a symbol. Authors should join values that map to a single conjugated word with a \ + \ sign with a space on each side of the \ + \ sign. (User agents may choose to accept values for a conjugated term that have been separated without the spaces.)
 See <a href="https://github.com/w3c/personalization-semantics/wiki/Best-practices-for-symbol-values">best practices for symbol values</a>.
-			</p>			    
-			    
- <p>When there is more than one concept that is not part of a single conjugated term, multiple concepts can be referenced by separating them 
+			</p>
+
+ <p>When there is more than one concept that is not part of a single conjugated term, multiple concepts can be referenced by separating them
 with white space. The order of multiple concepts should be the same as used in typical speech in the natural language of the content.
 </p>
 
-			<p>The reference numbers are the same references numbers used in Bliss (BCI numbers). Here is a link to the <a href="http://www.blissymbolics.net/BCI-AV_2020-03-09/BCI-AV_2020-03-09_(en+sv+no+fi)+derivations+symbols_8483-27158.pdf">BCI numbers (PDF)</a> and <a href="http://www.blissymbolics.net/BCI-AV_2020-03-09/BCI-AV_2020-03-09_(en+sv+no+fi+hu+de+nl+af+ru+lv+po+fr+es+pt+it+dk)+derivations+symbols_8483-27158.pdf">additional language translations (PDF)</a> at the time of publication and the <a href="http://www.blissymbolics.org/index.php/licensing">copyright licensing</a> from Bliss. For additional updates after publication see our <a href="https://github.com/w3c/personalization-semantics/wiki/Best-practices-for-symbol-values">best practices</a> for symbols page.</p> 
+			<p>The reference numbers are the same references numbers used in Bliss (BCI numbers). Here is a link to the <a href="http://www.blissymbolics.net/BCI-AV_2020-03-09/BCI-AV_2020-03-09_(en+sv+no+fi)+derivations+symbols_8483-27158.pdf">BCI numbers (PDF)</a> and <a href="http://www.blissymbolics.net/BCI-AV_2020-03-09/BCI-AV_2020-03-09_(en+sv+no+fi+hu+de+nl+af+ru+lv+po+fr+es+pt+it+dk)+derivations+symbols_8483-27158.pdf">additional language translations (PDF)</a> at the time of publication and the <a href="http://www.blissymbolics.org/index.php/licensing">copyright licensing</a> from Bliss. For additional updates after publication see our <a href="https://github.com/w3c/personalization-semantics/wiki/Best-practices-for-symbol-values">best practices</a> for symbols page.</p>
 				</div>
 	</section>
 	<section id="symbol-example">
@@ -28,9 +28,9 @@ with white space. The order of multiple concepts should be the same as used in t
 		<ol>
 		<li>Symbols for individual words.
         <pre class="example" title="Symbols for individual words">
-    	   &lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; &lt;span data-symbol=&quot;12324&quot;&gt;of&lt;/span&gt; 
+    	   &lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; &lt;span data-symbol=&quot;12324&quot;&gt;of&lt;/span&gt;
 	   &lt;span data-symbol=&quot;17511&quot; &gt;Tea&lt;/span&gt;</pre>		   </li>
-        <li>List of space-separated symbols for a text phrase. When there is more than one concept that is not part of a single conjugated term, multiple concepts are referenced by separating them with white space. 
+        <li>List of space-separated symbols for a text phrase. When there is more than one concept that is not part of a single conjugated term, multiple concepts are referenced by separating them with white space.
         <pre class="example" title="List of symbols for a text phrase">
             &lt;span data-symbol=&quot;13621 12324 17511&quot;&gt;cup of Tea&lt;/span&gt;</pre></li>
         <li>Symbols used with an image. (alt text represented as symbols)
@@ -40,7 +40,7 @@ with white space. The order of multiple concepts should be the same as used in t
 	<pre class="example" title="Symbols with conjugation">
 	 &lt;img src="her-name.png" alt="שמה" data-symbol="15691+14707"/></pre></li>
 	   </ul>
-			
+
     </section>
     <section>
     	<h3>Characteristics</h3>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -21,13 +21,10 @@
 		<p>Here are some examples using the <code>symbol</code> attribute.</p>
 		<ol>
 		<li>Symbols for individual words.
-        <pre class="example" title="Symbols for individual words">&lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; &lt;span data-symbol=&quot;12324&quot;&gt;of&lt;/span&gt; &lt;span data-symbol=&quot;17511&quot; &gt;Tea&lt;/span&gt;</pre>
+        <pre class="example" title="Symbols for individual words">&lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; of &lt;span data-symbol=&quot;17511&quot; &gt;Tea&lt;/span&gt;</pre>
 		</li>
-        <li>List of space-separated symbols for a text phrase. When there is more than one concept that is not part of a single conjugated term, multiple concepts are referenced by separating them with white space.
-        <pre class="example" title="List of symbols for a text phrase">&lt;span data-symbol=&quot;13621 12324 17511&quot;&gt;cup of Tea&lt;/span&gt;</pre>
-		</li>
-        <li>Symbols used with an image. (alt text represented as symbols)
-        <pre class="example" title="Symbols used with an image">&lt;img src="cuptea.png" data-symbol="13621 12324 17511" alt="cup of Tea"/></pre>
+		<li>Symbols used with an image (<code>alt</code> text represented as symbols).
+        <pre class="example" title="Symbols used with an image">&lt;img src="cuptea.png" data-symbol="13621" alt="Cup"/&gt;</pre>
 		</li>
 		<li>Symbols with conjugation. In this example a symbol is used for "her name" for the conjugated Hebrew word, <span lang="he" dir="rtl">שמה</span>. The /+/ is used with no spaces to join the conjugated values, "her" (14707) and "name" (15691). If the gender is not important, you can just use the value for name (15691).
 		<pre class="example" title="Symbols with conjugation">&lt;img src="her-name.png" alt="שמה" data-symbol="15691+14707"/></pre>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -27,20 +27,18 @@ with white space. The order of multiple concepts should be the same as used in t
 		<p>Here are some examples using the <code>symbol</code> attribute.</p>
 		<ol>
 		<li>Symbols for individual words.
-        <pre class="example" title="Symbols for individual words">
-    	   &lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; &lt;span data-symbol=&quot;12324&quot;&gt;of&lt;/span&gt;
-	   &lt;span data-symbol=&quot;17511&quot; &gt;Tea&lt;/span&gt;</pre>		   </li>
+        <pre class="example" title="Symbols for individual words">&lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; &lt;span data-symbol=&quot;12324&quot;&gt;of&lt;/span&gt; &lt;span data-symbol=&quot;17511&quot; &gt;Tea&lt;/span&gt;</pre>
+		</li>
         <li>List of space-separated symbols for a text phrase. When there is more than one concept that is not part of a single conjugated term, multiple concepts are referenced by separating them with white space.
-        <pre class="example" title="List of symbols for a text phrase">
-            &lt;span data-symbol=&quot;13621 12324 17511&quot;&gt;cup of Tea&lt;/span&gt;</pre></li>
+        <pre class="example" title="List of symbols for a text phrase">&lt;span data-symbol=&quot;13621 12324 17511&quot;&gt;cup of Tea&lt;/span&gt;</pre>
+		</li>
         <li>Symbols used with an image. (alt text represented as symbols)
-        <pre class="example" title="Symbols used with an image">
-	 &lt;img src="cuptea.png" data-symbol="13621 12324 17511" alt="cup of Tea"/></pre></li>
-		<li>Symbols with conjugation. In this example a symbol is used for "her name" for the conjugated Hebrew word, <span lang="he" dir="rtl">שמה</span>. The /+/ is used with no spaces to join the conjugated values, "her" (14707) and "name" (15691).  If the gender is not important, you can just use the value for name (15691).
-	<pre class="example" title="Symbols with conjugation">
-	 &lt;img src="her-name.png" alt="שמה" data-symbol="15691+14707"/></pre></li>
-	   </ul>
-
+        <pre class="example" title="Symbols used with an image">&lt;img src="cuptea.png" data-symbol="13621 12324 17511" alt="cup of Tea"/></pre>
+		</li>
+		<li>Symbols with conjugation. In this example a symbol is used for "her name" for the conjugated Hebrew word, <span lang="he" dir="rtl">שמה</span>. The /+/ is used with no spaces to join the conjugated values, "her" (14707) and "name" (15691). If the gender is not important, you can just use the value for name (15691).
+		<pre class="example" title="Symbols with conjugation">&lt;img src="her-name.png" alt="שמה" data-symbol="15691+14707"/></pre>
+		</li>
+	   </ol>
     </section>
     <section>
     	<h3>Characteristics</h3>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -21,7 +21,7 @@
 		<p>Here are some examples using the <code>symbol</code> attribute.</p>
 		<ol>
 		<li>Symbols for individual words.
-        <pre class="example" title="Symbols for individual words">&lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; of &lt;span data-symbol=&quot;17511&quot; &gt;Tea&lt;/span&gt;</pre>
+        <pre class="example" title="Symbols for individual words">&lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; of &lt;span data-symbol=&quot;17511&quot;&gt;Tea&lt;/span&gt;</pre>
 		</li>
 		<li>Symbols used with an image (<code>alt</code> text represented as symbols).
         <pre class="example" title="Symbols used with an image">&lt;img src="cuptea.png" data-symbol="13621" alt="Cup"/&gt;</pre>


### PR DESCRIPTION
As [discussed](https://www.w3.org/2022/05/02-personalization-minutes.html#t05) we're simplifying the `symbol` examples to remove anything that may be construed as translation. This PR also tightens up the parsing rules a bit, and doesn't stop us from having multiple symbols within one attribute value in future.

**HTML Previews:**

* Before: https://w3c.github.io/personalization-semantics/content/#symbol-explanation
* After: http://raw.githack.com/w3c/personalization-semantics/simplify-symbol-examples/content/index.html#symbol-explanation (also the examples section, below)

**Questions:**

I have some questions about this; the editorial question is: have I marked up "the plus sign (+)" part inkeeping with W3C house style?

For the other questions about this, I've started a thread on the mailing list: https://lists.w3.org/Archives/Public/public-personalization-tf/2022May/0005.html

This may clarify some matters relating to #203.